### PR TITLE
Makes Oshi's first 3 editions use the creditSplit.splitAddress 

### DIFF
--- a/.changeset/clean-eyes-scream.md
+++ b/.changeset/clean-eyes-scream.md
@@ -1,0 +1,7 @@
+---
+'@soundxyz/common': minor
+'@soundxyz/protocol': minor
+---
+
+- Makes Oshi's first 3 editions use the creditSplit.splitAddress for fundingRecipient
+- Adds SOUND_ADMIN_PUBLIC_ADDRESS to common/src/constants

--- a/common/src/constants.ts
+++ b/common/src/constants.ts
@@ -43,3 +43,5 @@ export const genres = [
   'Triphop',
   'World',
 ];
+
+export const SOUND_ADMIN_PUBLIC_ADDRESS = '0xed0faf139565bae4d856eeaffad7c81515457246';


### PR DESCRIPTION
Forgot to set the `splitAddress` as `fundingRecipient` in the seed editions